### PR TITLE
Add bakefile for generating native make/project files

### DIFF
--- a/cpp-build-system.bkl
+++ b/cpp-build-system.bkl
@@ -1,0 +1,68 @@
+// Input file for generating GNU Make makefiles and MSVS project files using
+// bakefile 1.x, see http://www.bakefile.org.
+
+toolsets = gnu vs2015;
+
+// MSVS doesn't require any special options.
+if ($toolset == gnu) {
+    compiler-options += "-std=c++14";
+}
+
+library static {
+    headers {
+        src/static/main/greeting.h
+    }
+
+    sources {
+        src/static/main/greeting.cpp
+    }
+}
+
+program static-test {
+    deps = static;
+
+    includedirs = src/static/main;
+
+    sources {
+        src/static/test/greeting_test.cpp
+        src/static/test/test.cpp
+    }
+}
+
+shared-library shared {
+    headers {
+        src/shared/main/mathematics.h
+    }
+
+    sources {
+        src/shared/main/add.cpp
+        src/shared/main/multiply.cpp
+    }
+}
+
+program shared-test {
+    deps = shared;
+
+    includedirs = src/shared/main;
+
+    sources {
+        src/shared/test/add_test.cpp
+        src/shared/test/multiply_test.cpp
+        src/shared/test/test.cpp
+    }
+}
+
+program executable {
+    deps = shared static;
+
+    // Auto-linking is used under Windows.
+    if ($toolset == gnu) {
+        libs = boost_date_time;
+    }
+
+    includedirs = src/static/main src/shared/main;
+
+    sources {
+        src/executable/main/main.cpp
+    }
+}

--- a/src/shared/main/mathematics.h
+++ b/src/shared/main/mathematics.h
@@ -1,13 +1,35 @@
 #ifndef CPP_BUILD_SYSTEMS_SHARED_MATHEMATICS_H
 #define CPP_BUILD_SYSTEMS_SHARED_MATHEMATICS_H
 
+#ifdef _WIN32
+    #ifdef _MSC_VER
+        #define CPP_BUILD_EXPORT __declspec(dllexport)
+        #define CPP_BUILD_IMPORT __declspec(dllimport)
+    #elif defined(__GNUC__)
+        #define CPP_BUILD_EXPORT __attribute__((dllexport))
+        #define CPP_BUILD_IMPORT __attribute__((dllimport))
+    #else
+        // Hope for auto-import/export to work.
+        #define CPP_BUILD_EXPORT
+        #define CPP_BUILD_IMPORT
+    #endif
+
+    #ifdef SHARED_EXPORTS
+        #define CPP_BUILD_EXPORT_DECL CPP_BUILD_EXPORT
+    #else
+        #define CPP_BUILD_EXPORT_DECL CPP_BUILD_IMPORT
+    #endif
+#else
+    #define CPP_BUILD_EXPORT_DECL
+#endif
+
 /**
  * Add two numbers together
  * @param a The first number to add together
  * @param b The second number to add together
  * @return The result of a + b
  */
-int add(int a, int b);
+CPP_BUILD_EXPORT_DECL int add(int a, int b);
 
 /**
  * Multiply two numbers together
@@ -15,6 +37,6 @@ int add(int a, int b);
  * @param b The second number to multiply together
  * @return The result of a - b
  */
-int multiply(int a, int b);
+CPP_BUILD_EXPORT_DECL int multiply(int a, int b);
 
 #endif


### PR DESCRIPTION
The first commit here is not build system related and should be probably applied to master itself as without it using the shared library won't work under Windows with any build system.

The second commit adds a trivial bakefile which can be processed with the program of the same name to generate GNUMakefile and MSVS solution which can then be used to build everything under Unix and Windows respectively. I didn't modify Vagrantfile because I have no simple way to test it, but Bakefile is written in Python and so is easy to run under Unix. As for Windows, there is a precompiled binary to download. I could also check in the generated files if you think this could be useful.